### PR TITLE
Correctly encode password for use in URI

### DIFF
--- a/PlexManager/PlexManager.groovy
+++ b/PlexManager/PlexManager.groovy
@@ -310,7 +310,7 @@ def getAuthenticationToken() {
     log.debug "Getting authentication token for Plex Server " + settings.plexServerIP      
 
     def params = [
-    	uri: "https://plex.tv/users/sign_in.json?user%5Blogin%5D=" + settings.plexUserName + "&user%5Bpassword%5D=" + settings.plexPassword,
+    	uri: "https://plex.tv/users/sign_in.json?user%5Blogin%5D=" + settings.plexUserName + "&user%5Bpassword%5D=" + URLEncoder.encode(settings.plexPassword),
         headers: [
             'X-Plex-Client-Identifier': 'Plex',
 			'X-Plex-Product': 'Device',


### PR DESCRIPTION
Passwords with certain characters in them need to be encoded before being used in a URI.
