### PR TITLE
Update to parse more device types

### DIFF
--- a/PlexManager/PlexManager.groovy
+++ b/PlexManager/PlexManager.groovy
@@ -87,16 +87,22 @@ def getClientList() {
 			  'X-Plex-Token': state.authenticationToken
 		]
 	]
-    httpGet(params) { resp ->
+ httpGet(params) { resp ->
         log.debug "Parsing plex.tv/devices.xml"
         def devices = resp.data.Device
         devices.each { thing ->    
         	thing.@provides.text().tokenize(',').each { provider ->
-            	if(provider == "player") {                
+            	if(provider == "player" || provider == "controller") {                
                 	thing.Connection.each { con ->
                         def uri = con.@uri.text()
                         def address = (uri =~ 'https?://([^:]+)')[0][1]                                           
                 		devs << ["${thing.@name.text()}|${thing.@clientIdentifier.text()}|${address}":"${thing.@name.text()}"]
+                	}
+                }else if(provider == "server"){
+                	thing.Connection.each { con ->
+                        def uri = con.@uri.text()
+                        def address = (uri =~ 'https?://([^:]+)')[0][1]                                           
+                		devs << ["${thing.@name.text()}[Server ${uri}|${thing.@clientIdentifier.text()}|${address}":"${thing.@name.text()}[Server${uri}]"]
                 	}
                 }
             }


### PR DESCRIPTION
Changes allow for Windows 10 app and the actual Plex Server to be picked up as clients in the SmartThings App

Server is placed in list with the IP address to make multi-server situations clearer.
