### PR TITLE
Complete re-work of get device logic

### DIFF
--- a/PlexManager/PlexManager.groovy
+++ b/PlexManager/PlexManager.groovy
@@ -59,15 +59,15 @@ def authPage() {
 
 def clientPage() {
 	if (!state.authenticationToken) { getAuthenticationToken() }
-    
 	def showUninstall = state.appInstalled
     def devs = getClientList()
-    //log.debug "devs: ${devs}"
 	return dynamicPage(name: "clientPage", uninstall: true, install: true) {
 		section("Client Selection Page") {
-        	paragraph("Devices with [status] on the end only provide status reporting and not control of the Plex Client via the ST App")
 			input "selectedClients", "enum", title: "Select Your Clients...", options: devs, multiple: true, required: false, submitOnChange: true
             href "authPage", title:"Go Back to Auth Page", description: "Tap to edit..."
+            input "pollEnable", "bool", title: "Enable Polling", defaultValue: "true", submitOnChange: true
+            input "showAllDevs", "bool", title: "Show All Devices Regardless of Capability", defaultValue: "false", submitOnChange: true
+            
   		}
     }
 }
@@ -77,7 +77,7 @@ def clientListOpt() {
 }
 
 def getClientList() {
-	def devs = []
+	def devs = [:]
 	log.debug "Executing 'getClientList'"
     
     def params = [
@@ -87,30 +87,62 @@ def getClientList() {
 			  'X-Plex-Token': state.authenticationToken
 		]
 	]
+    
+    // GET 3rd level IP of Plex server
+    
+    def plexServerIPShort = settings.plexServerIP.substring(0 , plexServerIP.lastIndexOf("."))
+    
     httpGet(params) { resp ->
         log.debug "Parsing plex.tv/devices.xml"
         def devices = resp.data.Device
-        devices.each { thing ->    
-        	thing.@provides.text().tokenize(',').each { provider ->
-            	if(provider == "player") {                
-                	thing.Connection.each { con ->
-                        def uri = con.@uri.text()
-                        def address = (uri =~ 'https?://([^:]+)')[0][1]                                           
-                		devs << ["${thing.@name.text()}|${thing.@clientIdentifier.text()}|${address}":"${thing.@name.text()}"]
-                	}
+        
+        def deviceNames = []
+        devices.each { thing ->
+        
+        	def capabilities = thing.@provides.text()
+            
+            // If these capabilities
+        	if(capabilities.contains("player")||capabilities.contains("client")||settings.showAllDevs){ 
+                     	
+                 //Define name based on name unless blank then use device name
+                 def whatToCallMe = "${thing.@name.text()}"
+                 if("${thing.@name.text()}"==""){whatToCallMe = "${thing.@device.text()}"}
+                 
+                 // Create alternative name if same name   
+                 def tempName = whatToCallMe
+        	     for (int i = 2; i < 100; i++) {
+                  	if(deviceNames.contains(tempName)){
+                  		tempName = "${whatToCallMe} #$i"
+                    }else{
+                      	whatToCallMe = tempName
+    	                break
+	                }
                 }
-            }
-            
-            if(thing.@device.text() == "Xbox One") {
-            	devs << ["${thing.@name.text()}[status]|${thing.@clientIdentifier.text()}|0.0.0.0":"${thing.@name.text()}[status]"]
-            }
-            
-            if(thing.@provides.text() == "client") {
-            	devs << ["${thing.@device.text()}[status]|${thing.@clientIdentifier.text()}|0.0.0.0":"${thing.@device.text()}[status]"]
-            }
-        }
+                    
+                deviceNames << whatToCallMe
+                         
+                def addressVal = "0.0.0.0"
+                    
+                // Get IP Address for those with an IP in the same range as your Plex Server if connection IP available (will only return a single entry for the local device)
+            	thing.Connection.each { con ->
+                    
+                    def uri = con.@uri.text()
+                    def address = (uri =~ 'https?://([^:]+)')[0][1]
+                        
+                    //Check if IP on same range
+                    if(plexServerIPShort == address.substring(0 , address.lastIndexOf("."))){
+                    	addressVal = address
+                	}        
+                }
+                 
+                // Add to list
+                if(devs.findIndexValues { it =~ /${thing.@clientIdentifier.text()}/ } == []){
+                	devs << ["${whatToCallMe}|${thing.@clientIdentifier.text()}|${addressVal}": whatToCallMe as String]
+            	} 
+        	}
+    	}   
     }
-    return devs.sort()
+    return devs.sort { a, b -> a.value.toLowerCase() <=> b.value.toLowerCase() }
 }
 
 def installed() {
@@ -127,9 +159,9 @@ def initialize() {
 
 def updated() {
 	log.debug "Updated with settings: ${settings}"
-
+    
 	unsubscribe()
-
+    
     if(selectedClients) {
     
         selectedClients.each { client ->
@@ -142,10 +174,7 @@ def updated() {
         }
     }
 
-    //state.authenticationToken = null;
-    //state.tokenUserName = null;
     state.poll = false;
-    //getClients();
     
     if (!state.authenticationToken) {
     	getAuthenticationToken()
@@ -157,19 +186,20 @@ def updated() {
     }
     
     subscribe(location, null, response, [filterEvents:false])   
+    
 }
 
 def uninstalled() {
-	//unsubscribe()
 	state.poll = false;
-    //removeChildDevices(getChildDevices())
+    removeChildDevices(getChildDevices())
 }
 
 private removeChildDevices(delete) {
+
 	try {
     	delete.each {
         	deleteChildDevice(it.deviceNetworkId)
-            log.info "Successfully Removed Child Device: ${it.displayName} (${it.deviceNetworkId})"
+    		log.info "Successfully Removed Child Device: ${it.displayName} (${it.deviceNetworkId})"
     		}
    		}
     catch (e) { log.error "There was an error (${e}) when trying to delete the child device" }
@@ -365,8 +395,11 @@ def regularPolling() {
     if(state.authenticationToken) {
         updateClientStatus();
     }
+    unschedule()
     
-    runIn(10, regularPolling);
+    if(pollEnable){
+    	runIn(10, regularPolling);
+    }
 }
 
 def updateClientStatus(){


### PR DESCRIPTION
Will now return players and clients, and ensure that control IP address is on the local LAN (some devices have two IP addresses LAN and WAN).

Added two switches:

To Disable Polling
To Return ALL devices regardless of capability (In case device does not correctly report capability)