### PR TITLE
Workaround malformed Device ID

### DIFF
--- a/PiRelayManager/WebOIPiManager.groovy
+++ b/PiRelayManager/WebOIPiManager.groovy
@@ -313,7 +313,7 @@ def switchChange(evt){
     def parts = evt.value.tokenize('.');
     def deviceId = parts[1];
     def GPIO = parts[5];
-    def state = parts[6];
+    def state = parts.last();
     
     log.debug state;
     


### PR DESCRIPTION
Thanks for the great app. Tiny fix to handle any malformed Device IDs. See https://community.smartthings.com/t/release-raspberry-pi-relay-controller-webiopi/36362/134